### PR TITLE
Fix: Problems with `True and `False constructors in original syntax

### DIFF
--- a/camlp4/Camlp4/Struct/Camlp4Ast2OCamlAst.ml
+++ b/camlp4/Camlp4/Struct/Camlp4Ast2OCamlAst.ml
@@ -325,9 +325,9 @@ module Make (Ast : Sig.Camlp4Ast) = struct
         assert False ]
   and row_field = fun
     [ <:ctyp<>> -> []
-    | <:ctyp< `$i$ >> -> [Rtag i True []]
-    | <:ctyp< `$i$ of & $t$ >> -> [Rtag i True (List.map ctyp (list_of_ctyp t []))]
-    | <:ctyp< `$i$ of $t$ >> -> [Rtag i False (List.map ctyp (list_of_ctyp t []))]
+    | <:ctyp< `$i$ >> -> [Rtag (conv_con i) True []]
+    | <:ctyp< `$i$ of & $t$ >> -> [Rtag (conv_con i) True (List.map ctyp (list_of_ctyp t []))]
+    | <:ctyp< `$i$ of $t$ >> -> [Rtag (conv_con i) False (List.map ctyp (list_of_ctyp t []))]
     | <:ctyp< $t1$ | $t2$ >> -> row_field t1 @ row_field t2
     | t -> [Rinherit (ctyp t)] ]
   and name_tags = fun

--- a/camlp4/Camlp4/Struct/Camlp4Ast2OCamlAst.ml
+++ b/camlp4/Camlp4/Struct/Camlp4Ast2OCamlAst.ml
@@ -811,7 +811,7 @@ value varify_constructors var_names =
     | ExFlo loc s -> mkexp loc (Pexp_constant (Const_float (remove_underscores s)))
     | ExFor loc i e1 e2 df el ->
         let e3 = ExSeq loc el in
-        mkexp loc (Pexp_for (with_loc i loc) (expr e1) (expr e2) (mkdirection df) (expr e3))
+        mkexp loc (Pexp_for (mkpat loc (Ppat_var (with_loc i loc))) (expr e1) (expr e2) (mkdirection df) (expr e3))
     | <:expr@loc< fun [ $PaLab _ lab po$ when $w$ -> $e$ ] >> ->
         mkfun loc lab None (patt_of_lab loc lab po) e w
     | <:expr@loc< fun [ $PaOlbi _ lab p e1$ when $w$ -> $e2$ ] >> ->

--- a/camlp4/boot/Camlp4.ml
+++ b/camlp4/boot/Camlp4.ml
@@ -14811,11 +14811,13 @@ module Struct =
             and row_field =
               function
               | Ast.TyNil _ -> []
-              | Ast.TyVrn (_, i) -> [ Rtag (i, true, []) ]
+              | Ast.TyVrn (_, i) -> [ Rtag ((conv_con i), true, []) ]
               | Ast.TyOfAmp (_, (Ast.TyVrn (_, i)), t) ->
-                  [ Rtag (i, true, (List.map ctyp (list_of_ctyp t []))) ]
+                  [ Rtag ((conv_con i), true,
+                      (List.map ctyp (list_of_ctyp t []))) ]
               | Ast.TyOf (_, (Ast.TyVrn (_, i)), t) ->
-                  [ Rtag (i, false, (List.map ctyp (list_of_ctyp t []))) ]
+                  [ Rtag ((conv_con i), false,
+                      (List.map ctyp (list_of_ctyp t []))) ]
               | Ast.TyOr (_, t1, t2) -> (row_field t1) @ (row_field t2)
               | t -> [ Rinherit (ctyp t) ]
             and name_tags =
@@ -15438,8 +15440,8 @@ module Struct =
                   let e3 = ExSeq (loc, el)
                   in
                     mkexp loc
-                      (Pexp_for ((with_loc i loc), (expr e1), (expr e2),
-                         (mkdirection df), (expr e3)))
+                      (Pexp_for ((mkpat loc (Ppat_var (with_loc i loc))),
+                         (expr e1), (expr e2), (mkdirection df), (expr e3)))
               | Ast.ExFun (loc, (Ast.McArr (_, (PaLab (_, lab, po)), w, e)))
                   -> mkfun loc lab None (patt_of_lab loc lab po) e w
               | Ast.ExFun (loc,

--- a/camlp4/test/fixtures/bug-camlp4o-benjamin-monate.ml
+++ b/camlp4/test/fixtures/bug-camlp4o-benjamin-monate.ml
@@ -12,4 +12,4 @@ type u = True | False
 let g x = function | True -> () | False -> ()
 
 type v = [`True | `False]
-let h x = function | `True -> () | `False -> ()
+let h (x: v) = match x with `True -> () | `False -> ()


### PR DESCRIPTION
This resolves the problematic edge-case of using ``True` and ``False` constructors in original syntax.
See the modified test case for an example.

Relevant issues in the OCaml bugtracker:
- http://caml.inria.fr/mantis/view.php?id=4520
- http://caml.inria.fr/mantis/view.php?id=4705
- http://caml.inria.fr/mantis/view.php?id=5778

Relevant commits:
- eb11b9507177946af8eda5d913995930adaa40b4
- d7596d10b55c0d586a7059a9f5d34e52a523b41b
- fef654ed9d5df8031cb3399019ab2d7bc7a3d8c3
- 4316d60e3e3f2506deb72faf244528d383ac5c02
