### PR TITLE
Allow to specify LIBDIR, BINDIR and PKGDIR at configuration time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
 OB := ocamlbuild -classic-display -no-ocamlfind
-PKGDIR ?= /usr/local/lib/
 -include config.sh
 
 .PHONY: default

--- a/configure
+++ b/configure
@@ -20,9 +20,10 @@ else
     ext_exe=""
 fi
 
-LIBDIR="$standard_library"
 OCAMLC="`which ocamlc`"
-BINDIR="`dirname $OCAMLC`"
+: ${LIBDIR:="$standard_library"}
+: ${BINDIR:="`dirname $OCAMLC`"}
+: ${PKGDIR:="`ocamlc -where`/camlp4"}
 
 cat >> config.sh <<EOF
 A="$ext_lib"
@@ -30,4 +31,5 @@ O="$ext_obj"
 EXE="$ext_exe"
 LIBDIR="$LIBDIR"
 BINDIR="$BINDIR"
+PKGDIR="$PKGDIR"
 EOF


### PR DESCRIPTION
Would be better to rewrite all the configuration scripts from scratch, but well ...

To be able to do something like https://github.com/ocaml/opam-repository/pull/2023/files#diff-723ac13d2cd18792d857888b700d9854R6
