### PR TITLE
Fix for Mantis 6221.

### DIFF
--- a/camlp4/Camlp4Parsers/Camlp4OCamlParser.ml
+++ b/camlp4/Camlp4Parsers/Camlp4OCamlParser.ml
@@ -484,7 +484,7 @@ module Make (Syntax : Sig.Camlp4Syntax) = struct
       [ [ t1 = SELF; "as"; "'"; i = a_ident -> <:ctyp< $t1$ as '$i$ >> ]
       | "arrow" RIGHTA
         [ t1 = SELF; "->"; t2 = SELF -> <:ctyp< $t1$ -> $t2$ >>
-        | i = TRY [i = a_LIDENT; ":" -> i]; t1 = ctyp LEVEL "star"; "->"; t2 = SELF ->
+        | (i, t1) = TRY [i = a_LIDENT; ":"; t1 = ctyp LEVEL "star"; "->" -> (i, t1)]; t2 = SELF ->
             <:ctyp< ( ~ $i$ : $t1$ ) -> $t2$ >>
         | i = a_OPTLABEL; t1 = ctyp LEVEL "star"; "->"; t2 = SELF ->
             <:ctyp< ( ? $i$ : $t1$ ) -> $t2$ >>


### PR DESCRIPTION
Fix for [Mantis 6221](http://caml.inria.fr/mantis/view.php?id=6221).

Test case:

```
$ cat field.ml
<:ctyp< a:b >>
```

Before:

```
$ camlp4of field.ml
File "field.ml", line 1, characters 10-11:
While expanding quotation "ctyp" in a position of "str_item":
  Parse error: "->" expected after [ctyp level star] (in [ctyp])
```

After:

```
$ camlp4of field.ml
Ast.TyCol (_loc, (Ast.TyId (_loc, (Ast.IdLid (_loc, "a")))),
  (Ast.TyId (_loc, (Ast.IdLid (_loc, "b")))))
```
