### PR TITLE
Make camlp4 insensitive to CDPATH.

### DIFF
--- a/build/camlp4-bootstrap.sh
+++ b/build/camlp4-bootstrap.sh
@@ -15,7 +15,10 @@
 # README: to bootstrap camlp4 have a look at build/camlp4-bootstrap-recipe.txt
 
 set -e
-cd `dirname $0`/..
+if [ ! -e camlp4/META.in ] ; then
+  echo "script $0 invoked from the wrong location"
+  exit 1
+fi
 
 . ./config.sh
 export PATH=$BINDIR:$PATH

--- a/build/camlp4-byte-only.sh
+++ b/build/camlp4-byte-only.sh
@@ -13,7 +13,11 @@
 #########################################################################
 
 set -e
-cd `dirname $0`/..
+if [ ! -e camlp4/META.in ] ; then
+  echo "script $0 invoked from the wrong location"
+  exit 1
+fi
+
 . ./config.sh
 . build/camlp4-targets.sh
 set -x

--- a/build/camlp4-mkCamlp4Ast.sh
+++ b/build/camlp4-mkCamlp4Ast.sh
@@ -13,7 +13,10 @@
 #########################################################################
 
 set -e
-cd `dirname $0`/..
+if [ ! -e camlp4/META.in ] ; then
+  echo "script $0 invoked from the wrong location"
+  exit 1
+fi
 
 . ./config.sh
 export PATH=$BINDIR:$PATH

--- a/build/camlp4-native-only.sh
+++ b/build/camlp4-native-only.sh
@@ -13,7 +13,11 @@
 #########################################################################
 
 set -e
-cd `dirname $0`/..
+if [ ! -e camlp4/META.in ] ; then
+  echo "script $0 invoked from the wrong location"
+  exit 1
+fi
+
 . ./config.sh
 . build/camlp4-targets.sh
 set -x

--- a/build/camlp4-targets.sh
+++ b/build/camlp4-targets.sh
@@ -32,7 +32,7 @@ for i in camlp4boot camlp4r camlp4rf camlp4o camlp4of camlp4oof camlp4orf; do
   CAMLP4_NATIVE="$CAMLP4_NATIVE camlp4/$i.native$EXE"
 done
 
-cd camlp4
+cd ./camlp4
 for dir in Camlp4Parsers Camlp4Printers Camlp4Filters; do
   for file in $dir/*.ml; do
     base=camlp4/$dir/`basename $file .ml`

--- a/build/install.sh
+++ b/build/install.sh
@@ -13,8 +13,10 @@
 #########################################################################
 
 set -e
-
-cd `dirname $0`/..
+if [ ! -e camlp4/META.in ] ; then
+  echo "script $0 invoked from the wrong location"
+  exit 1
+fi
 
 # Save the following environment variables before sourcing config.sh
 # since it will overwrite them and the user might have set them to
@@ -108,7 +110,7 @@ installlibdir() {
 mkdir -p $BINDIR
 mkdir -p $LIBDIR/camlp4
 
-cd _build
+cd ./_build
 
 echo "Installing camlp4..."
 installbin camlp4/camlp4prof.byte$EXE $BINDIR/camlp4prof$EXE
@@ -128,7 +130,7 @@ installbin camlp4/camlp4orf.native$EXE $BINDIR/camlp4orf.opt$EXE
 installbin camlp4/camlp4r.native$EXE $BINDIR/camlp4r.opt$EXE
 installbin camlp4/camlp4rf.native$EXE $BINDIR/camlp4rf.opt$EXE
 
-cd camlp4
+cd ./camlp4
 CAMLP4DIR=$LIBDIR/camlp4
 for dir in Camlp4Parsers Camlp4Printers Camlp4Filters Camlp4Top; do
   echo "Installing $dir..."


### PR DESCRIPTION
Ref: https://github.com/ocaml/opam-repository/issues/2561.

This is the second time I encounter this bug, and I've seen people on IRC occasionally come in with the same report. I believe there are no downside to these changes, and while the problem is fairly obscure, I think this is worth merging.

It's interesting that practically nothing except camlp4 uses cd in build scripts.
