### PR TITLE
Add DESTDIR support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
 OB := ocamlbuild -classic-display -no-ocamlfind
+DESTDIR=
+
 -include config.sh
 
 OB += $(OB_FLAGS)
@@ -19,12 +21,12 @@ all: byte native
 
 .PHONY: install
 install:
-	./build/install.sh
+	env DESTDIR=$(DESTDIR) ./build/install.sh
 
 .PHONY: install-META
 install-META: camlp4/META
-	mkdir -p ${PKGDIR}/camlp4/
-	cp -f camlp4/META ${PKGDIR}/camlp4/
+	mkdir -p $(DESTDIR)${PKGDIR}/camlp4/
+	cp -f camlp4/META $(DESTDIR)${PKGDIR}/camlp4/
 
 camlp4/META: camlp4/META.in
 	sed -e s/@@VERSION@@/${version}/g $? > $@

--- a/build/install.sh
+++ b/build/install.sh
@@ -26,8 +26,8 @@ SAVED_LIBDIR="${LIBDIR}"
 
 . ./config.sh
 
-BINDIR="${SAVED_BINDIR:-${BINDIR}}"
-LIBDIR="${SAVED_LIBDIR:-${LIBDIR}}"
+BINDIR="$DESTDIR${SAVED_BINDIR:-${BINDIR}}"
+LIBDIR="$DESTDIR${SAVED_LIBDIR:-${LIBDIR}}"
 
 not_installed=$PWD/_build/not_installed
 


### PR DESCRIPTION
When building rpm packages it is required to install the resulting
binaries below an "offset" directory. Such directory is specified with
make DESTDIR=$RPM_BUILD_ROOT in almost all packages.

Without this change make install will fail. Using make
SOME_DIRECTORY_VARIABLE=$RPM_BUILD_ROOT/$WHATEVER_WAS_IN_SOME_DIRECTORY_VARIABLE
will fail when SOME_DIRECTORY_VARIABLE is compiled into the binaries.
The offset will become part of the desired directories. This leads to
runtime errors. And it leads to package build failures because the
post-build checks scan for RPM_BUILD_ROOT usage in binaries.

Signed-off-by: Olaf Hering olaf@aepfle.de
