### PR TITLE
Camlp4Top/Rprint.ml: support Osig_ellipsis

### DIFF
--- a/camlp4/Camlp4Top/Rprint.ml
+++ b/camlp4/Camlp4Top/Rprint.ml
@@ -368,7 +368,9 @@ and needs_semi =
   | Osig_type _ rs -> rs <> Orec_next
   | Osig_typext _ _
   | Osig_modtype _ _
-  | Osig_value _ _ _ -> True ]
+  | Osig_value _ _ _ -> True
+  | Osig_ellipsis -> False
+  ]
 and print_out_signature ppf =
   fun
   [ [] -> ()
@@ -425,7 +427,9 @@ and print_out_sig_item ppf =
             } ]
       in
       fprintf ppf "@[<2>%s %a :@ %a%a@]" kwd value_ident name
-        Toploop.print_out_type.val ty pr_prims prims ]
+        Toploop.print_out_type.val ty pr_prims prims
+  | Osig_ellipsis -> fprintf ppf "..."
+  ]
 
 and print_out_type_decl kwd ppf { otype_name    = name
                                 ; otype_params  = args


### PR DESCRIPTION
Osig_ellipsis was added in OCaml 4.03+dev by

```
5adbb67a458f6f63deb1c1000f887ff87371c706
Jacques Garrigue
PR#6648: show_module should indicate its elision
(add Osig_ellipsis to outcometree)
git-svn-id: http://caml.inria.fr/svn/ocaml/trunk@15573y
```

It prevents building Camlp4 because of a non-exhaustive-matching
warning turned into an error.
