### PR TITLE
Fix unary arithmetic operations

### DIFF
--- a/camlp4/Camlp4Parsers/Camlp4OCamlRevisedParser.ml
+++ b/camlp4/Camlp4Parsers/Camlp4OCamlRevisedParser.ml
@@ -210,14 +210,19 @@ New syntax:\
     else "-" ^ n
   ;
 
-  value mkumin _loc f arg =
+  value mkumin _loc arg =
     match arg with
     [ <:expr< $int:n$ >> -> <:expr< $int:neg_string n$ >>
     | <:expr< $int32:n$ >> -> <:expr< $int32:neg_string n$ >>
     | <:expr< $int64:n$ >> -> <:expr< $int64:neg_string n$ >>
     | <:expr< $nativeint:n$ >> -> <:expr< $nativeint:neg_string n$ >>
     | <:expr< $flo:n$ >> -> <:expr< $flo:neg_string n$ >>
-    | _ -> <:expr< $lid:"~" ^ f$ $arg$ >> ];
+    | _ -> <:expr< $lid:"~-"$ $arg$ >> ];
+
+  value mkumin_f _loc arg =
+    match arg with
+    [ <:expr< $flo:n$ >> -> <:expr< $flo:neg_string n$ >>
+    | _ -> <:expr< $lid:"~-."$ $arg$ >> ];
 
   value mklistexp _loc last =
     loop True where rec loop top =
@@ -711,8 +716,8 @@ New syntax:\
         | e1 = SELF; "lsr"; e2 = SELF -> <:expr< $e1$ lsr $e2$ >>
         | e1 = SELF; op = infixop4; e2 = SELF -> <:expr< $op$ $e1$ $e2$ >> ]
       | "unary minus" NONA
-        [ "-"; e = SELF -> mkumin _loc "-" e
-        | "-."; e = SELF -> mkumin _loc "-." e ]
+        [ "-"; e = SELF -> mkumin _loc e
+        | "-."; e = SELF -> mkumin_f _loc e ]
       | "apply" LEFTA
         [ e1 = SELF; e2 = SELF -> <:expr< $e1$ $e2$ >>
         | "assert"; e = SELF -> mkassert _loc e

--- a/camlp4/Camlp4Parsers/Camlp4OCamlRevisedParser.ml
+++ b/camlp4/Camlp4Parsers/Camlp4OCamlRevisedParser.ml
@@ -224,6 +224,20 @@ New syntax:\
     [ <:expr< $flo:n$ >> -> <:expr< $flo:neg_string n$ >>
     | _ -> <:expr< $lid:"~-."$ $arg$ >> ];
 
+  value mkuplus _loc arg =
+    match arg with
+    [ <:expr< $int:n$ >> -> <:expr< $int:n$ >>
+    | <:expr< $int32:n$ >> -> <:expr< $int32:n$ >>
+    | <:expr< $int64:n$ >> -> <:expr< $int64:n$ >>
+    | <:expr< $nativeint:n$ >> -> <:expr< $nativeint:n$ >>
+    | <:expr< $flo:n$ >> -> <:expr< $flo:n$ >>
+    | _ -> <:expr< $lid:"~+"$ $arg$ >> ];
+
+  value mkuplus_f _loc arg =
+    match arg with
+    [ <:expr< $flo:n$ >> -> <:expr< $flo:n$ >>
+    | _ -> <:expr< $lid:"~+."$ $arg$ >> ];
+
   value mklistexp _loc last =
     loop True where rec loop top =
       fun
@@ -717,7 +731,9 @@ New syntax:\
         | e1 = SELF; op = infixop4; e2 = SELF -> <:expr< $op$ $e1$ $e2$ >> ]
       | "unary minus" NONA
         [ "-"; e = SELF -> mkumin _loc e
-        | "-."; e = SELF -> mkumin_f _loc e ]
+        | "-."; e = SELF -> mkumin_f _loc e
+        | "+"; e = SELF -> mkuplus _loc e
+        | "+."; e = SELF -> mkuplus_f _loc e ]
       | "apply" LEFTA
         [ e1 = SELF; e2 = SELF -> <:expr< $e1$ $e2$ >>
         | "assert"; e = SELF -> mkassert _loc e


### PR DESCRIPTION
Hello there! This patch attempts to fix some issues with unary arithmetic operations.
(1) Unary minus (was reported as [#115 for utop](https://github.com/diml/utop/issues/115)):
    ocaml# -.1;;
    - : int = -1
    This should result in a type error.

(2) Unary plus:
    ocaml# +1;;
    Error: Parse error: illegal begin of top_phrase

I by no means am a camlp4 expert, so If my approach is completely and utterly wrong, please do not hesitate to tell me about that. Thank you!
