### PR TITLE
New: Quotation tag may now include the dot character

### DIFF
--- a/camlp4/Camlp4/Struct/Lexer.mll
+++ b/camlp4/Camlp4/Struct/Lexer.mll
@@ -208,6 +208,7 @@ module Make (Token : Sig.Camlp4Token)
   let identchar =
     ['A'-'Z' 'a'-'z' '_' '\192'-'\214' '\216'-'\246' '\248'-'\255' '\'' '0'-'9']
   let ident = (lowercase|uppercase) identchar*
+  let quote_tag = (lowercase|uppercase) (identchar|'.')*
   let locname = ident
   let not_star_symbolchar =
     ['$' '!' '%' '&' '+' '-' '.' '/' ':' '<' '=' '>' '?' '@' '^' '|' '~' '\\']
@@ -358,7 +359,7 @@ module Make (Token : Sig.Camlp4Token)
       "(*"
         { store c; with_curr_loc comment c; parse comment c                     }
     | "*)"                                                            { store c }
-    | '<' (':' ident)? ('@' locname)? '<'
+    | '<' (':' quote_tag)? ('@' locname)? '<'
         { store c;
           if quotations c then with_curr_loc quotation c; parse comment c       }
     | ident                                             { store_parse comment c }
@@ -414,15 +415,15 @@ module Make (Token : Sig.Camlp4Token)
     | symbolchar* as tok                                   { SYMBOL("<@" ^ tok) }
 
   and maybe_quotation_colon c = parse
-    | (ident as name) '<'
+    | (quote_tag as name) '<'
       { mk_quotation quotation c name "" (1 + String.length name)               }
-    | (ident as name) '@' (locname as loc) '<'
+    | (quote_tag as name) '@' (locname as loc) '<'
       { mk_quotation quotation c name loc
                      (2 + String.length loc + String.length name)               }
     | symbolchar* as tok                                   { SYMBOL("<:" ^ tok) }
 
   and quotation c = parse
-    | '<' (':' ident)? ('@' locname)? '<'    {                          store c ;
+    | '<' (':' quote_tag)? ('@' locname)? '<'                         { store c ;
                                                       with_curr_loc quotation c ;
                                                               parse quotation c }
     | ">>"                                                            { store c }
@@ -442,7 +443,7 @@ module Make (Token : Sig.Camlp4Token)
     | eof                                   { err Unterminated_antiquot (loc c) }
     | newline
       { update_loc c None 1 false 0; store_parse (antiquot name) c              }
-    | '<' (':' ident)? ('@' locname)? '<'
+    | '<' (':' quote_tag)? ('@' locname)? '<'
       { store c; with_curr_loc quotation c; parse (antiquot name) c             }
     | _                                         { store_parse (antiquot name) c }
 


### PR DESCRIPTION
This change allows to use the dot character (`.`) inside a quotation tag, which makes for prettier and intuitively meaningful identifiers when dealing with nested hierarchies of quotations, like this:

```
<:Namespace.parser< ... >>
```

An automated test for this change would involve some bureaucracy: registering a quotation in a syntax plugin and then referring to it in a separate camlp4-processed module. Since the change is trivial (it obviously doesn't break anything), I believe that we can get away without a proper test.
