### PR TITLE
Enable safe-string.

### DIFF
--- a/_tags
+++ b/_tags
@@ -16,7 +16,7 @@
 
 # We want -g everywhere it's possible
 true: debug
-
+true: safe_string
 <camlp4/**/*>: use_import
 <camlp4/**/*.{byte,native}>: use_dynlink
 <camlp4/config/gen_import.*>: use_ocamlcommon

--- a/camlp4/Camlp4/Struct/Camlp4Ast2OCamlAst.ml
+++ b/camlp4/Camlp4/Struct/Camlp4Ast2OCamlAst.ml
@@ -77,15 +77,16 @@ module Make (Ast : Sig.Camlp4Ast) = struct
   ;
 
   value remove_underscores s =
-    let l = String.length s in
+    let s = Bytes.of_string s in
+    let l = Bytes.length s in
     let rec remove src dst =
       if src >= l then
-        if dst >= l then s else String.sub s 0 dst
+        if dst >= l then s else Bytes.sub s 0 dst
       else
-        match s.[src] with
+        match Bytes.get s src with
         [ '_' -> remove (src + 1) dst
         |  c  -> do { Bytes.set s dst c; remove (src + 1) (dst + 1) } ]
-    in remove 0 0
+    in Bytes.to_string (remove 0 0)
   ;
 
   value mkloc = Loc.to_ocaml_location;

--- a/camlp4/Camlp4Parsers/Camlp4AstLoader.ml
+++ b/camlp4/Camlp4Parsers/Camlp4AstLoader.ml
@@ -30,14 +30,14 @@ module Make (Ast : Camlp4.Sig.Ast) = struct
     let str =
       let buf = Buffer.create 2047 in
       let () = Stream.iter (Buffer.add_char buf) strm
-      in Buffer.contents buf in
+      in Buffer.to_bytes buf in
     let magic_len = String.length ast_magic in
-    let buffer = String.create magic_len in
+    let buffer = Bytes.create magic_len in
     do {
-      String.blit str 0 buffer 0 magic_len;
-      if buffer = ast_magic then ()
-      else failwith (Format.sprintf "Bad magic: %S vs %S" buffer ast_magic);
-      Marshal.from_string str magic_len;
+      Bytes.blit str 0 buffer 0 magic_len;
+      if Bytes.to_string buffer = ast_magic then ()
+      else failwith (Format.sprintf "Bad magic: %S vs %S" (Bytes.to_string buffer) ast_magic);
+      Marshal.from_bytes str magic_len;
     };
 
   open Camlp4.PreCast;

--- a/camlp4/boot/Camlp4.ml
+++ b/camlp4/boot/Camlp4.ml
@@ -15410,16 +15410,17 @@ module Struct =
               with | (Failure _ as exn) -> Loc.raise loc exn
               
             let remove_underscores s =
-              let l = String.length s in
+              let s = Bytes.of_string s in
+              let l = Bytes.length s in
               let rec remove src dst =
                 if src >= l
-                then if dst >= l then s else String.sub s 0 dst
+                then if dst >= l then s else Bytes.sub s 0 dst
                 else
-                  (match s.[src] with
+                  (match Bytes.get s src with
                    | '_' -> remove (src + 1) dst
                    | c -> (Bytes.set s dst c; remove (src + 1) (dst + 1)))
-              in remove 0 0
-              
+              in Bytes.to_string (remove 0 0)
+
             let mkloc = Loc.to_ocaml_location
               
             let mkghloc loc = Loc.to_ocaml_location (Loc.ghostify loc)


### PR DESCRIPTION
I made this PR against the 4.04 branch but it should also work on the current trunk. All functions used are available for ocaml >= 4.02.