### PR TITLE
Use POSIX "command" instead of non-standard "which"

### DIFF
--- a/configure
+++ b/configure
@@ -54,12 +54,12 @@ else
     ext_exe=""
 fi
 
-OCAMLC="`which ocamlc`"
+OCAMLC="`command -v ocamlc`"
 LIBDIR="${LIBDIR:-$standard_library}"
 BINDIR="${BINDIR:-`dirname $OCAMLC`}"
 PKGDIR="${PKGDIR:-$standard_library}"
 
-if [ -x "`which ocamlopt`" ]; then
+if [ -x "`command -v ocamlopt`" ]; then
     OB_FLAGS=""
 else
     OB_FLAGS="-byte-plugin"


### PR DESCRIPTION
```which``` is non installed by default on a *base* Arch Linux installation:

```
juergen@pidsley:~/ocaml/camlp4 → ./configure
./configure: line 57: which: command not found
```

whereas ```command``` is part of any *POSIX* shell


