### PR TITLE
Removed warnings 3,8 and 52.

### DIFF
--- a/camlp4/Camlp4/ErrorHandler.ml
+++ b/camlp4/Camlp4/ErrorHandler.ml
@@ -164,11 +164,7 @@ value print ppf = gen_print ppf default_handler;
 value try_print ppf = gen_print ppf (fun _ -> raise);
 
 value to_string exn =
-  let buf = Buffer.create 128 in
-  let () = bprintf buf "%a" print exn in
-  Buffer.contents buf;
+  Format.asprintf "%a" print exn;
 
 value try_to_string exn =
-  let buf = Buffer.create 128 in
-  let () = bprintf buf "%a" try_print exn in
-  Buffer.contents buf;
+  Format.asprintf "%a" try_print exn;

--- a/camlp4/Camlp4/Options.ml
+++ b/camlp4/Camlp4/Options.ml
@@ -27,11 +27,11 @@ value rec action_arg s sl =
         match sl with
         [ [s :: sl] ->
             try do { f (bool_of_string s); Some sl } with
-            [ Invalid_argument "bool_of_string" -> None ]
+            [ Invalid_argument _ -> None ]
         | [] -> None ]
       else
         try do { f (bool_of_string s); Some sl } with
-        [ Invalid_argument "bool_of_string" -> None ]
+        [ Invalid_argument _ -> None ]
   | Arg.Set r -> if s = "" then do { r.val := True; Some sl } else None
   | Arg.Clear r -> if s = "" then do { r.val := False; Some sl } else None
   | Arg.Rest f -> do { List.iter f [s :: sl]; Some [] }
@@ -52,21 +52,21 @@ value rec action_arg s sl =
         match sl with
         [ [s :: sl] ->
             try do { f (int_of_string s); Some sl } with
-            [ Failure "int_of_string" -> None ]
+            [ Failure _ -> None ]
         | [] -> None ]
       else
         try do { f (int_of_string s); Some sl } with
-        [ Failure "int_of_string" -> None ]
+        [ Failure _ -> None ]
   | Arg.Set_int r ->
       if s = "" then
         match sl with
         [ [s :: sl] ->
             try do { r.val := (int_of_string s); Some sl } with
-            [ Failure "int_of_string" -> None ]
+            [ Failure _ -> None ]
         | [] -> None ]
       else
         try do { r.val := (int_of_string s); Some sl } with
-        [ Failure "int_of_string" -> None ]
+        [ Failure _ -> None ]
   | Arg.Float f ->
       if s = "" then
         match sl with
@@ -181,7 +181,7 @@ value add name spec descr =
 
 value fold f init =
   let spec_list = init_spec_list.val @ ext_spec_list.val in
-  let specs = Sort.list (fun (k1, _, _) (k2, _, _) -> k1 >= k2) spec_list in
+  let specs = List.sort (fun (k1, _, _) (k2, _, _) -> String.compare k2 k1) spec_list in
   List.fold_right f specs init;
 
 value parse anon_fun argv =

--- a/camlp4/Camlp4/Struct/Quotation.ml
+++ b/camlp4/Camlp4/Struct/Quotation.ml
@@ -116,8 +116,7 @@ module Make (Ast : Sig.Camlp4Ast)
       in fprintf ppf "@\n%a@]@." ErrorHandler.print exn;
 
     value to_string x =
-      let b = Buffer.create 50 in
-      let () = bprintf b "%a" print x in Buffer.contents b;
+      Format.asprintf "%a" print x;
   end;
   let module M = ErrorHandler.Register Error in ();
   open Error;

--- a/camlp4/Camlp4/Struct/Token.ml
+++ b/camlp4/Camlp4/Struct/Token.ml
@@ -90,8 +90,7 @@ module Make (Loc : Sig.Loc)
           fprintf ppf "Illegal constructor %S" con ];
 
     value to_string x =
-      let b = Buffer.create 50 in
-      let () = bprintf b "%a" print x in Buffer.contents b;
+      Format.asprintf "%a" print x;
   end;
   let module M = ErrorHandler.Register Error in ();
 

--- a/camlp4/Camlp4Bin.ml
+++ b/camlp4/Camlp4Bin.ml
@@ -67,7 +67,7 @@ value rewrite_and_load n x =
     end
   end in
   do {
-    match (n, String.lowercase x) with
+    match (n, String.lowercase_ascii x) with
     [ ("Parsers"|"", "pa_r.cmo"      | "r"  | "ocamlr" | "ocamlrevised" | "camlp4ocamlrevisedparser.cmo") -> load [pa_r]
     | ("Parsers"|"", "rr" | "reloaded" | "ocamlreloaded" | "camlp4ocamlreloadedparser.cmo") -> load [pa_rr]
     | ("Parsers"|"", "pa_o.cmo"      | "o"  | "ocaml" | "camlp4ocamlparser.cmo") -> load [pa_r; pa_o]

--- a/camlp4/Camlp4Filters/Camlp4Profiler.ml
+++ b/camlp4/Camlp4Filters/Camlp4Profiler.ml
@@ -53,10 +53,8 @@ module Make (AstFilters : Camlp4.Sig.AstFilters) = struct
   end;
 
   value decorate_this_expr e id =
-    let buf = Buffer.create 42 in
     let _loc = Ast.loc_of_expr e in
-    let () = Format.bprintf buf "%s @@ %a@?" id Loc.dump _loc in
-    let s = Buffer.contents buf in
+    let s = Format.asprintf "%s @@ %a@?" id Loc.dump _loc in
     <:expr< let () = Camlp4prof.count $`str:s$ in $e$ >>;
 
   value rec decorate_fun id =

--- a/camlp4/Camlp4Parsers/Camlp4GrammarParser.ml
+++ b/camlp4/Camlp4Parsers/Camlp4GrammarParser.ml
@@ -34,9 +34,7 @@ module Make (Syntax : Sig.Camlp4Syntax) = struct
   value pp = new PP.printer ~comments:False ();
 
   value string_of_patt patt =
-    let buf = Buffer.create 42 in
-    let () = Format.bprintf buf "%a@?" pp#patt patt in
-    let str = Buffer.contents buf in
+    let str = Format.asprintf "%a@?" pp#patt patt in
     if str = "" then assert False else str;
 
   value split_ext = ref False;

--- a/camlp4/Camlp4Top/Rprint.ml
+++ b/camlp4/Camlp4Top/Rprint.ml
@@ -69,7 +69,7 @@ value print_out_value ppf tree =
     | Oval_char c -> fprintf ppf "'%s'" (Char.escaped c)
     | Oval_string s ->
         try fprintf ppf "\"%s\"" (String.escaped s) with
-        [ Invalid_argument "String.create" -> fprintf ppf "<huge string>" ]
+        [ Invalid_argument _ -> fprintf ppf "<huge string>" ]
     | Oval_list tl ->
         fprintf ppf "@[<1>[%a]@]" (print_tree_list print_tree ";") tl
     | Oval_array tl ->
@@ -210,7 +210,8 @@ and print_simple_out_type ppf =
       }
   | Otyp_alias _ _ | Otyp_poly _ _ | Otyp_open
   | Otyp_arrow _ _ _ | Otyp_constr _ [_ :: _] as ty ->
-      fprintf ppf "@[<1>(%a)@]" print_out_type ty ]
+      fprintf ppf "@[<1>(%a)@]" print_out_type ty
+  | Otyp_attribute (_, _) -> ()]
   in
   print_tkind ppf
 and print_out_constr ppf (name, tyl, ret) =

--- a/camlp4/mkcamlp4.ml
+++ b/camlp4/mkcamlp4.ml
@@ -34,7 +34,7 @@ value (interfaces, options, includes) =
     | ["-vnum" :: _] ->
         do { printf "%s@." version; exit 0 }
     | [ arg :: args ] when check_suffix arg ".cmi" ->
-        let basename = String.capitalize (Filename.chop_suffix
+        let basename = String.capitalize_ascii (Filename.chop_suffix
                          (Filename.basename arg) ".cmi") in
         self ([ basename :: interf ], opts, incl) args
     | [ arg :: args ] ->


### PR DESCRIPTION
Mostly Format.bprintf is replaced by Format.asprintf.