### PR TITLE
fix build wrt to ocaml PR#881

### DIFF
--- a/camlp4/Camlp4Top/Rprint.ml
+++ b/camlp4/Camlp4Top/Rprint.ml
@@ -173,8 +173,7 @@ and print_simple_out_type ppf =
         [ Ovar_fields fields ->
             print_list print_row_field (fun ppf -> fprintf ppf "@;<1 -2>| ")
               ppf fields
-        | Ovar_name id tyl ->
-            fprintf ppf "@[%a%a@]" print_typargs tyl print_ident id ]
+        | Ovar_typ typ -> print_out_type_2 ppf typ ]
       in
       fprintf ppf "%s[%s@[<hv>@[<hv>%a@]%a ]@]" (if non_gen then "_" else "")
         (if closed then if tags = None then "= " else "< "


### PR DESCRIPTION
I don't know how to run that code but the old code looks buggy, it's printing ['a t] instead of [t 'a] as the new code does.