### PR TITLE
Fix configure on newer Cygwin tools

### DIFF
--- a/configure
+++ b/configure
@@ -41,8 +41,8 @@ elif [ $major -ne 4 -o $minor -ne 4 ]; then
     exit 2
 fi
 
-ocamlc -config | sed 's/: /="/;s/$/"/' > config.sh
-ocamlc -config | sed 's/^/let /;s/: / = "/;s/$/"/' > myocamlbuild_config.ml
+ocamlc -config | tr -d '\015' | sed 's/: /="/;s/$/"/' > config.sh
+ocamlc -config | tr -d '\015' | sed 's/^/let /;s/: / = "/;s/$/"/' > myocamlbuild_config.ml
 
 # Add a few things to config.sh
 


### PR DESCRIPTION
The Cygwin packages for awk, grep and sed were updated on 20 February 2017 so that they no longer automatically strip \r characters on binary mounts.

I've fixed this on 4.04 as that's where I'm working, but it's wanted on all branches.

References:
  * https://cygwin.com/ml/cygwin/2017-02/msg00152.html
  * https://cygwin.com/ml/cygwin/2017-02/msg00189.html
  * https://cygwin.com/ml/cygwin/2017-02/msg00188.html