### PR TITLE
Fix make byte for systems with no natdynlink

### DIFF
--- a/myocamlbuild.ml
+++ b/myocamlbuild.ml
@@ -76,7 +76,7 @@ let () =
       else
         let exe =
           "camlp4boot" ^
-          if !Options.native_plugin then
+          if C.ocamlnat then
             (* If we are using a native plugin, we might as well use a native
                preprocessor. *)
             ".native"


### PR DESCRIPTION
2a31a83 builds a native-code preprocessor if ocamlbuild supports native code. However, it's possible to have systems which support native code but don't have natdynlink (e.g. Cygwin without flexdll support) and in this case the build fails.

Part of the fix for the main issue in https://github.com/ocaml/opam/issues/2276 - once merged, I'll submit an opam-repository PR for the rest.

This commit should be cherry-picked to 4.02, 4.03, 4.04, 4.05 and 4.06.