### PR TITLE
Fixes and tweaks to opam file

### DIFF
--- a/configure
+++ b/configure
@@ -6,6 +6,7 @@ unset LC_ALL LC_CTYPE LC_COLLATE LC_MESSAGES LC_MONETARY LC_NUMERIC LC_TIME
 
 set -e
 
+PINNED=0
 for i in "$@"; do
   case $i in
     --bindir=*)
@@ -16,6 +17,9 @@ for i in "$@"; do
       ;;
     --pkgdir=*)
       PKGDIR=${i##*=}
+      ;;
+    --pinned*)
+      PINNED=1
       ;;
     *)
       echo "usage: ./configure [--bindir=<dir>] [--libdir=<dir>] [--pkgdir=<dir>]" 1>&2
@@ -37,7 +41,14 @@ if [ $major -lt 4 -o \( $major -eq 4 -a $minor -lt 2 \) ]; then
     exit 2
 elif [ $major -ne 4 -o $minor -ne 7 ]; then
     echo "This version of Camlp4 is for OCaml 4.07 but you are using OCaml $ocaml_version."
-    echo "If building Camlp4 directly from git, use the $major.$minor branch."
+    if [ -d .git ] ; then
+      if [ $PINNED -eq 1 ] ; then
+        echo "You've used the wrong opam pin URL for this switch.">&2
+        echo "Try https://github.com/ocaml/camlp4.git#$major.$minor instead">&2
+      else
+        echo "You appear to be building Camlp4 from git, so try the $major.$minor branch."
+      fi
+    fi
     exit 2
 fi
 

--- a/opam
+++ b/opam
@@ -5,7 +5,7 @@ maintainer: "jeremie@dimino.org"
 homepage: "https://github.com/ocaml/camlp4"
 license: "LGPLv2"
 build: [
-  ["./configure" "--bindir=%{bin}%" "--libdir=%{lib}%/ocaml" "--pkgdir=%{lib}%"]
+  ["./configure" "--bindir=%{bin}%" "--libdir=%{lib}%/ocaml" "--pkgdir=%{lib}%" "--pinned"]
   [make "clean"]
   [make "all"] {ocaml-native-dynlink}
   [make "byte"] {!ocaml-native-dynlink}

--- a/opam
+++ b/opam
@@ -1,17 +1,20 @@
 opam-version: "1.2"
+version: "4.07+trunk"
+authors: ["Daniel de Rauglaudre" "Nicolas Pouillard"]
 maintainer: "jeremie@dimino.org"
 homepage: "https://github.com/ocaml/camlp4"
-bug-reports: "https://github.com/ocaml/camlp4/issues"
-dev-repo: "https://github.com/ocaml/camlp4.git"
 license: "LGPLv2"
 build: [
   ["./configure" "--bindir=%{bin}%" "--libdir=%{lib}%/ocaml" "--pkgdir=%{lib}%"]
-  [make "all"]
+  [make "clean"]
+  [make "all"] {ocaml-native-dynlink}
+  [make "byte"] {!ocaml-native-dynlink}
 ]
 install: [make "install" "install-META"]
-depends: ["ocamlfind" {build}]
+depends: ["ocamlbuild" {build}]
 remove: [
-  ["rm" "-rf" "%{lib}%/camlp4"]
+  ["ocamlfind" "remove" "camlp4"]
+  ["rm" "-rf" "%{lib}%/ocaml/camlp4"]
   ["rm" "-f" "%{bin}%/camlp4"  "%{bin}%/camlp4boot" "%{bin}%/mkcamlp4"
              "%{bin}%/camlp4r" "%{bin}%/camlp4rf"   "%{bin}%/camlp4orf"
              "%{bin}%/camlp4o" "%{bin}%/camlp4of"   "%{bin}%/camlp4oof"
@@ -19,6 +22,5 @@ remove: [
              "%{bin}%/camlp4o.opt" "%{bin}%/camlp4oof.opt" "%{bin}%/camlp4r.opt"
   ]
 ]
-depexts: [
-  [ ["centos"] ["which"] ]
-]
+bug-reports: "https://github.com/ocaml/camlp4/issues"
+dev-repo: "https://github.com/ocaml/camlp4.git"


### PR DESCRIPTION
This splits `make all` into `make byte` or `make all`, depending on configuration (as the opam-repository files do) and also correctly bases the decision of `ocaml-native-dynlink` rather than just `ocaml-native`.

I've also added a hidden parameter `--pinned` to `configure` which is used for the repository-stored `opam` file in the repository and allows `configure` to display a more meaningful hint to an opam user who specifies `opam pin add camlp4 --dev-repo` since this command will virtually always fail.