### PR TITLE
Correct 4.06 branch opam file

### DIFF
--- a/myocamlbuild.ml
+++ b/myocamlbuild.ml
@@ -76,7 +76,7 @@ let () =
       else
         let exe =
           "camlp4boot" ^
-          if !Options.native_plugin then
+          if C.ocamlnat then
             (* If we are using a native plugin, we might as well use a native
                preprocessor. *)
             ".native"

--- a/opam
+++ b/opam
@@ -1,4 +1,5 @@
 opam-version: "1.2"
+version: "4.06+trunk"
 maintainer: "jeremie@dimino.org"
 homepage: "https://github.com/ocaml/camlp4"
 bug-reports: "https://github.com/ocaml/camlp4/issues"
@@ -6,7 +7,8 @@ dev-repo: "https://github.com/ocaml/camlp4.git"
 license: "LGPLv2"
 build: [
   ["./configure" "--bindir=%{bin}%" "--libdir=%{lib}%/ocaml" "--pkgdir=%{lib}%"]
-  [make "all"]
+  [make "all"] {ocaml-native-dynlink}
+  [make "byte"] {!ocaml-native-dynlink}
 ]
 install: [make "install" "install-META"]
 depends: ["ocamlfind" {build}]
@@ -22,3 +24,4 @@ remove: [
 depexts: [
   [ ["centos"] ["which"] ]
 ]
+available: [ (!preinstalled) & (ocaml-version >= "4.06") & (ocaml-version < "4.07") ]


### PR DESCRIPTION
For convenience, the commit from #126 is included.

Corrects the build instructions in the opam file and constrains it the correct OCaml version.

