### PR TITLE
Correct 4.03 branch opam file

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -8,6 +8,14 @@ i386)
   sudo make install
   cd ..
   rm -rf ocaml
+
+  git clone git://github.com/ocaml/ocamlbuild
+  cd ocamlbuild
+  make
+  sudo make install
+  cd ..
+  rm -rf ocamlbuild
+
   ./configure && make && sudo make install
   ;;
 *)

--- a/myocamlbuild.ml
+++ b/myocamlbuild.ml
@@ -76,7 +76,7 @@ let () =
       else
         let exe =
           "camlp4boot" ^
-          if !Options.native_plugin then
+          if C.ocamlnat then
             (* If we are using a native plugin, we might as well use a native
                preprocessor. *)
             ".native"

--- a/opam
+++ b/opam
@@ -1,15 +1,21 @@
 opam-version: "1.2"
+version: "4.03+trunk"
+authors: ["Daniel de Rauglaudre" "Nicolas Pouillard"]
 maintainer: "jeremie@dimino.org"
 homepage: "https://github.com/ocaml/camlp4"
-bug-reports: "https://github.com/ocaml/camlp4/issues"
-dev-repo: "https://github.com/ocaml/camlp4.git"
 license: "LGPLv2"
 build: [
   ["./configure" "--bindir=%{bin}%" "--libdir=%{lib}%/ocaml" "--pkgdir=%{lib}%"]
-  [make "all"]
+  [make "all"] {ocaml-native-dynlink}
+  [make "byte"] {!ocaml-native-dynlink}
 ]
-install: [make "install" "install-META"]
-depends: ["ocamlfind" {build}]
+depends: [
+  "ocamlbuild" {build}
+  "conf-which" {build}
+]
+install: [
+  [make "install" "install-META"]
+]
 remove: [
   ["rm" "-rf" "%{lib}%/camlp4"]
   ["rm" "-f" "%{bin}%/camlp4"  "%{bin}%/camlp4boot" "%{bin}%/mkcamlp4"
@@ -19,6 +25,6 @@ remove: [
              "%{bin}%/camlp4o.opt" "%{bin}%/camlp4oof.opt" "%{bin}%/camlp4r.opt"
   ]
 ]
-depexts: [
-  [ ["centos"] ["which"] ]
-]
+available: [ (!preinstalled) & (ocaml-version >= "4.03") & (ocaml-version < "4.04") ]
+bug-reports: "https://github.com/ocaml/camlp4/issues"
+dev-repo: "https://github.com/ocaml/camlp4.git"


### PR DESCRIPTION
4.03 version of #128. For convenience, the commit from #126 is included.

Corrects the build instructions in the opam file and constrains it the correct OCaml version.