### PR TITLE
fix make.sh: exit 1 if campl4 fails

### DIFF
--- a/make.sh
+++ b/make.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-camlp4orf -v 2> /dev/null || (cat install && exit 1)
+camlp4orf -v 2> /dev/null || { cat install && exit 1; }
 
 version="`camlp4 -version`"
 sed -e "s/@@VERSION@@/$version/g" META.in > META


### PR DESCRIPTION
This PR resolves the issue #140. 