### PR TITLE
Fix Makefile wrt SAVED_BINDIR and SAVED_LIBDIR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ all: byte native
 
 .PHONY: install
 install:
-	env DESTDIR=$(DESTDIR) sh ./build/install.sh
+	env DESTDIR=$(DESTDIR) BINDIR=$(BINDIR) LIBDIR=$(LIBDIR) sh ./build/install.sh
 
 .PHONY: install-META
 install-META: camlp4/META


### PR DESCRIPTION
Export BINDIR and LIBDIR via env, so build/install.sh reads the
correct ones. The Makefile reads config.sh, which properly
double-quotes path strings, and GNU Make will then export variables
with double-quotes; that's fine, because build/install.sh itself reads
config.sh, which reads the variables the way they are intended to
be... except for BINDIR and LIBDIR that are kept from the environment if
defined, so they can be overridden by the Makefile. This change
ensures that they should be properly and not overly quoted.

This patch makes the opam installation work on Debian GNU/Linux using GNU Make 4.2.1 and /bin/sh being dash 0.5.8-2.10, where it otherwise wouldn't.