### PR TITLE
fix usage of DEFINE-d identifiers in patterns in standard syntax

### DIFF
--- a/camlp4/Camlp4Parsers/Camlp4MacroParser.ml
+++ b/camlp4/Camlp4Parsers/Camlp4MacroParser.ml
@@ -189,7 +189,10 @@ module Make (Syntax : Sig.Camlp4Syntax) = struct
             expr: LEVEL "simple"
               [ [ UIDENT $x$ -> (new reloc _loc)#expr e ]]
             ;
-            patt: LEVEL "simple"
+            patt: LEVEL "apply"
+            (* in the revised grammar 'UIDENT' only occurs at the level "simple",
+               but in the standard grammar 'patt_constr' is a possible production
+               of the level "apply", and includes 'UIDENT'. *)
               [ [ UIDENT $x$ ->
                     let p = substp _loc [] e
                     in (new reloc _loc)#patt p ]]
@@ -210,7 +213,7 @@ module Make (Syntax : Sig.Camlp4Syntax) = struct
                     else
                       incorrect_number _loc el sl ] ]
             ;
-            patt: LEVEL "simple"
+            patt: LEVEL "apply"
               [ [ UIDENT $x$; param = SELF ->
                     let pl =
                       match param with


### PR DESCRIPTION
fixes #148

Note that both parameter-less macros (as in the bug report) and
parametrized macros are affected.

I wasn't able to find a testsuite in Camlp4, so I did not add
a test. I believe that the regression potential of this change is
fairly low: it only affects the action of DEFINE in patterns (which
are currently broken in standard syntax), not in expressions, and
I tested it in both standard and revised syntaxes.

Testcase for standard syntax:

    DEFINE FOO = ""
    DEFINE ID(x) = x

    let test x = match x with
    | Some(FOO) -> Some(FOO)
    | Some(ID "bar") -> Some(ID "bar")
    | Some _ -> Some "baz"
    | None -> None

Testcase for revised syntax:

    DEFINE FOO = "";
    DEFINE ID(x) = x;

    value test x = match x with
    [ Some FOO -> Some FOO
    | Some (ID "bar") -> Some (ID "bar")
    | Some _ -> Some "baz"
    | None -> None ];