### PR TITLE
Added code to work on Power Systems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
 language: c
+os: linux
+arch: 
+    - amd64
+    - ppc64le
 script: bash -ex .travis-ci.sh
 env:
   - OCAML_BRANCH=4.11


### PR DESCRIPTION

Thanks for the code, 
## What do these changes do?
Added Architecture "ppc64le"
## Are there changes in behavior for the user?
No

The code is failing for both ppc64le and AMD64 for test case OCAML_BRANCH=trunk XARCH=i386 CONFIGURE_ARGS=--skip-version-check

Can you please check and fix the code
Getting error as :The command "bash -ex .travis-ci.sh" exited with 2.