### PR TITLE
Add missing dependencies on Unix and Dynlink

### DIFF
--- a/_tags
+++ b/_tags
@@ -27,6 +27,10 @@ true: safe_string
 <camlp4/*.{byte,native}>: use_unix
 <camlp4/camlp4boot.*>: -use_unix
 
+<camlp4/boot/Camlp4.ml>: use_dynlink
+<camlp4/Camlp4/Struct/DynLoader.ml>: use_dynlink
+<camlp4/Camlp4Printers/Camlp4AutoPrinter.ml>: use_unix
+
 #<**/*.ml*>: warn_error(A-3), warn(-3)
 
 # The tag "camlp4boot" is for preprocessing using camlp4/boot/camlp4boot.byte


### PR DESCRIPTION
Silences the alert proposed in ocaml/ocaml#11198, but this PR can be merged regardless.