### PR TITLE
Add support for OCaml 5.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 _build/
+_opam/
 config.sh
 myocamlbuild_config.ml
 camlp4/boot/*.old

--- a/camlp4/Camlp4/Options.ml
+++ b/camlp4/Camlp4/Options.ml
@@ -35,6 +35,7 @@ value rec action_arg s sl =
   | Arg.Set r -> if s = "" then do { r.val := True; Some sl } else None
   | Arg.Clear r -> if s = "" then do { r.val := False; Some sl } else None
   | Arg.Rest f -> do { List.iter f [s :: sl]; Some [] }
+  | Arg.Rest_all f -> do { f [s :: sl]; Some [] }
   | Arg.String f ->
       if s = "" then
         match sl with
@@ -95,6 +96,8 @@ value rec action_arg s sl =
       match (if s = "" then sl else [s :: sl]) with
       [ [s :: sl] when List.mem s syms -> do { f s; Some sl }
       | _ -> None ]
+  | Arg.Expand _f ->
+      invalid_arg "Arg.Expand is unimplemented" (* TODO *)
   ];
 
 value common_start s1 s2 =

--- a/camlp4/Camlp4/Struct/Camlp4Ast2OCamlAst.ml
+++ b/camlp4/Camlp4/Struct/Camlp4Ast2OCamlAst.ml
@@ -1057,14 +1057,15 @@ value varify_constructors var_names =
                                 mktyp _loc (Ptyp_poly ampersand_vars ty')))
       in
       let e = mk_newtypes vars in
-      [{pvb_pat=pat; pvb_expr=e; pvb_attributes=[]; pvb_loc = mkloc _loc} :: acc]
+      [{pvb_pat=pat; pvb_expr=e; pvb_attributes=[]; pvb_loc = mkloc _loc; pvb_constraint = None} :: acc]
     | <:binding@_loc< $p$ = ($e$ : ! $vs$ . $ty$) >> ->
         [{pvb_pat=patt <:patt< ($p$ : ! $vs$ . $ty$ ) >>;
           pvb_expr=expr e;
           pvb_attributes=[];
-          pvb_loc=mkloc _loc} :: acc]
+          pvb_loc=mkloc _loc;
+          pvb_constraint = None} :: acc]
     | <:binding@_loc< $p$ = $e$ >> -> [{pvb_pat=patt p; pvb_expr=expr e; pvb_attributes=[];
-                                        pvb_loc=mkloc _loc} :: acc]
+                                        pvb_loc=mkloc _loc; pvb_constraint = None} :: acc]
     | <:binding<>> -> acc
     | _ -> assert False ]
   and match_case x acc =

--- a/camlp4/Camlp4Top/Rprint.ml
+++ b/camlp4/Camlp4Top/Rprint.ml
@@ -149,7 +149,9 @@ value pr_present =
 
 value rec print_out_type ppf =
   fun
-  [ Otyp_alias ty s -> fprintf ppf "@[%a as '%s@]" print_out_type ty s
+  [ Otyp_alias {non_gen; aliased; alias } ->
+      fprintf ppf "@[%a@ as '%s@]"
+        print_out_type aliased alias
   | ty -> print_out_type_1 ppf ty ]
 and print_out_type_1 ppf =
   fun
@@ -175,7 +177,7 @@ and print_simple_out_type ppf =
   | Otyp_tuple tyl ->
       fprintf ppf "@[<1>(%a)@]" (print_typlist print_out_type " *") tyl
   | Otyp_stuff s -> fprintf ppf "%s" s
-  | Otyp_variant non_gen row_fields closed tags ->
+  | Otyp_variant (row_fields, closed, tags) ->
       let print_present ppf =
         fun
         [ None | Some [] -> ()
@@ -188,16 +190,16 @@ and print_simple_out_type ppf =
               ppf fields
         | Ovar_typ typ -> print_out_type_2 ppf typ ]
       in
-      fprintf ppf "%s[%s@[<hv>@[<hv>%a@]%a ]@]" (if non_gen then "_" else "")
+      fprintf ppf "[%s@[<hv>@[<hv>%a@]%a ]@]"
         (if closed then if tags = None then "= " else "< "
          else if tags = None then "> "
          else "? ")
         print_fields row_fields
         print_present tags
-  | Otyp_object fields rest ->
-      fprintf ppf "@[<2>< %a >@]" (print_fields rest) fields
-  | Otyp_class ng id tyl ->
-      fprintf ppf "@[%a%s#%a@]" print_typargs tyl (if ng then "_" else "")
+  | Otyp_object {fields; open_row} ->
+      fprintf ppf "@[<2>< %a >@]" (print_fields open_row) fields
+  | Otyp_class (id, tyl) ->
+      fprintf ppf "@[%a#%a@]" print_typargs tyl
         print_ident id
   | Otyp_manifest ty1 ty2 ->
       fprintf ppf "@[<2>%a ==@ %a@]" print_out_type ty1 print_out_type ty2
@@ -220,7 +222,7 @@ and print_simple_out_type ppf =
             fl;
           fprintf ppf ")@]"
       }
-  | Otyp_alias _ _ | Otyp_poly _ _ | Otyp_open
+  | Otyp_alias _ | Otyp_poly _ _ | Otyp_open
   | Otyp_arrow _ _ _ | Otyp_constr _ [_ :: _] as ty ->
       fprintf ppf "@[<1>(%a)@]" print_out_type ty
   | Otyp_attribute (_, _) -> ()]
@@ -267,18 +269,18 @@ and print_out_extension_constructor ppf ext =
     print_extended_type
     (if ext.oext_private = Asttypes.Private then " private" else "")
     print_out_constr {ocstr_name = ext.oext_name; ocstr_args = ext.oext_args; ocstr_return_type = ext.oext_ret_type}
-and print_fields rest ppf =
+and print_fields open_row ppf =
   fun
   [ [] ->
-      match rest with
-      [ Some non_gen -> fprintf ppf "%s.." (if non_gen then "_" else "")
-      | None -> () ]
+      match open_row with
+      [ true -> fprintf ppf ".."
+      | false -> () ]
   | [(s, t)] ->
       do {
         fprintf ppf "%s : %a" s print_out_type t;
-        match rest with
-        [ Some _ -> fprintf ppf ";@ "
-        | None -> () ];
+        match open_row with
+        [ true -> fprintf ppf ";@ "
+        | false -> () ];
         print_fields rest ppf []
       }
   | [(s, t) :: l] ->

--- a/camlp4/Camlp4Top/Rprint.ml
+++ b/camlp4/Camlp4Top/Rprint.ml
@@ -149,7 +149,7 @@ value pr_present =
 
 value rec print_out_type ppf =
   fun
-  [ Otyp_alias {non_gen; aliased; alias } ->
+  [ Otyp_alias {non_gen=_; aliased; alias } ->
       fprintf ppf "@[%a@ as '%s@]"
         print_out_type aliased alias
   | ty -> print_out_type_1 ppf ty ]
@@ -273,18 +273,18 @@ and print_fields open_row ppf =
   fun
   [ [] ->
       match open_row with
-      [ true -> fprintf ppf ".."
-      | false -> () ]
+      [ True -> fprintf ppf ".."
+      | False -> () ]
   | [(s, t)] ->
       do {
         fprintf ppf "%s : %a" s print_out_type t;
         match open_row with
-        [ true -> fprintf ppf ";@ "
-        | false -> () ];
-        print_fields rest ppf []
+        [ True -> fprintf ppf ";@ "
+        | False -> () ];
+        print_fields open_row ppf []
       }
   | [(s, t) :: l] ->
-      fprintf ppf "%s : %a;@ %a" s print_out_type t (print_fields rest) l ]
+      fprintf ppf "%s : %a;@ %a" s print_out_type t (print_fields open_row) l ]
 and print_row_field ppf (l, opt_amp, tyl) =
   let pr_of ppf =
     if opt_amp then fprintf ppf " of@ &@ "

--- a/camlp4/META.in
+++ b/camlp4/META.in
@@ -28,7 +28,7 @@ description = "Base for Camlp4 syntax extensions"
 directory = "+camlp4"
 
 # For the toploop:
-requires(byte,toploop) = "dynlink"
+requires(byte,toploop) = "dynlink camlp-streams"
 archive(byte,toploop,camlp4o) = "camlp4o.cma"
 archive(byte,toploop,camlp4r) = "camlp4r.cma"
 
@@ -38,7 +38,7 @@ archive(syntax,preprocessor,camlp4r) = "-parser r -parser rp -printer p"
 preprocessor = "camlp4"
 
 package "lib" (
-  requires = "camlp4 dynlink"
+  requires = "camlp4 dynlink camlp-streams"
   version = "@@VERSION@@"
   description = "Camlp4 library"
   archive(byte) = "camlp4lib.cma"
@@ -54,7 +54,7 @@ package "gramlib" (
 
 # dont use camlp4.lib and camlp4.fulllib together'
 package "fulllib" (
-  requires = "camlp4 dynlink"
+  requires = "camlp4 dynlink camlp-streams"
   version = "@@VERSION@@"
   description = "Camlp4 library"
   error(pkg_camlp4.lib) = "camlp4.lib and camlp4.fulllib are incompatible"

--- a/camlp4/boot/Camlp4.ml
+++ b/camlp4/boot/Camlp4.ml
@@ -16655,6 +16655,7 @@ module Struct =
                       pvb_expr = e;
                       pvb_attributes = [];
                       pvb_loc = mkloc _loc;
+                      pvb_constraint = None;
                     } :: acc
               | Ast.BiEq (_loc, p,
                   (Ast.ExTyc (_, e, (Ast.TyPol (_, vs, ty))))) ->
@@ -16664,6 +16665,7 @@ module Struct =
                     pvb_expr = expr e;
                     pvb_attributes = [];
                     pvb_loc = mkloc _loc;
+                    pvb_constraint = None;
                   } :: acc
               | Ast.BiEq (_loc, p, e) ->
                   {
@@ -16671,6 +16673,7 @@ module Struct =
                     pvb_expr = expr e;
                     pvb_attributes = [];
                     pvb_loc = mkloc _loc;
+                    pvb_constraint = None;
                   } :: acc
               | Ast.BiNil _ -> acc
               | _ -> assert false

--- a/configure
+++ b/configure
@@ -39,7 +39,7 @@ ocaml_version=`ocamlc -version`
 major=`echo $ocaml_version | cut -d. -f1`
 minor=`echo $ocaml_version | cut -d. -f2`
 
-camlp4_version=5.0
+camlp4_version=5.1
 camlp4_major=`echo $camlp4_version | cut -d. -f1`
 camlp4_minor=`echo $camlp4_version | cut -d. -f2`
 

--- a/opam
+++ b/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "camlp4"
-version: "5.0"
+version: "5.1"
 authors: ["Daniel de Rauglaudre" "Nicolas Pouillard"]
 maintainer: "ygrek@autistici.org"
 homepage: "https://github.com/camlp4/camlp4"
@@ -18,7 +18,7 @@ build: [
   [make "byte"] {!ocaml:native-dynlink}
 ]
 depends: [
-  "ocaml" {>= "5.0" & < "5.1"}
+  "ocaml" {>= "5.1" & < "5.2"}
   "ocamlbuild" {build}
   "ocamlfind" {build}
   "camlp-streams"


### PR DESCRIPTION
Besides the changes due to AST updates, the main source of changes originates in https://github.com/ocaml/ocaml/pull/1391. That change leads to errors of the kind:

```
ocamlfind ocamlopt -c -for-pack Camlp4.Struct -g -safe-string -w Z -I camlp4/import -package camlp-streams -pp 'camlp4/boot/camlp4boot.byte -D OPT' -I camlp4/Camlp4/Struct -I camlp4/Camlp4 -I camlp4/config -I camlp4 -o camlp4/Camlp4/Struct/Loc.cmx camlp4/Camlp4/Struct/Loc.ml
File "camlp4/Camlp4/Struct/Loc.ml", line 1:
Error: camlp4/Camlp4/ErrorHandler.cmx
       was built with -for-pack Camlp4, but the
       current unit Loc is built with -for-pack Camlp4.Struct
Command exited with code 2.
```

The solution found is to move some modules inside `Struct` pack (and append a suffix to avoid issues with duplication) and just `include` them from the outside so the public interface remains unchanged.

There might be some breaking changes though, for example, `Camlp4Ast` changed its location.

Thanks @kit-ty-kate and @ygrek for the help.